### PR TITLE
Added new options for gene size

### DIFF
--- a/inst/htmlwidgets/lib/geneviewer-0.1.8/Themes.js
+++ b/inst/htmlwidgets/lib/geneviewer-0.1.8/Themes.js
@@ -110,11 +110,24 @@ function getMarker(markerName, xPos, yPos, size, height = null) {
 }
 
 function getGenePath(marker, length, markerSize, options = {}) {
-    const sizeDefaults = {
-        small: { scale: 0.75 },
-        medium: { scale: 1 },
-        large: { scale: 1.25 }
-    };
+  const sizeDefaults = {
+      extraExtraSmall: { scale: 0.4 },
+      extraSmall: { scale: 0.5 },
+      verySmall: { scale: 0.65 },
+      small: { scale: 0.75 },
+      slightlySmall: { scale: 0.8 },
+      normal: { scale: 0.85 },
+      medium: { scale: 1 },
+      slightlyLarge: { scale: 1.1 },
+      large: { scale: 1.25 },
+      veryLarge: { scale: 1.5 },
+      extraLarge: { scale: 1.75 },
+      extraExtraLarge: { scale: 2.0 },
+      huge: { scale: 2.5 },
+      massive: { scale: 3.0 },
+      custom: { scale: options.scale || 1 }  // Custom scale here
+  };
+
 
     const markerDefaults = {
         arrow: { arrowheadWidth: 10, arrowheadHeight: 30, markerHeight: 15 },
@@ -126,8 +139,12 @@ function getGenePath(marker, length, markerSize, options = {}) {
         // Add other marker types if needed
     };
 
-    const sizeOptions = sizeDefaults[markerSize] || sizeDefaults.medium;
+    // Check if markerSize is an object to handle custom scale
+    const sizeOptions = typeof markerSize === 'object' && markerSize.type === 'custom'
+        ? { scale: markerSize.scale }
+        : sizeDefaults[markerSize] || sizeDefaults.medium;
     const markerOptions = markerDefaults[marker] || {};
+    const scale = sizeOptions.scale;
 
     const combinedOptions = mergeOptions(markerOptions, "genePathOptions", options);
 


### PR DESCRIPTION
**Size Categories**

The function includes several predefined size categories, each associated with a specific scaling factor to adjust the size of the gene marker:

1. `extraExtraSmall`: A very small size, scaled to 40% of the base size.
2. `extraSmall`: Slightly larger than the smallest size, scaled to 50% of the base size.
3. `verySmall`: A small size, scaled to 65% of the base size.
4. `small`: A moderately small size, scaled to 75% of the base size.
5. `slightlySmall`: A slightly smaller size, scaled to 80% of the base size.
6. `normal`: The standard size, scaled to 85% of the base size.
7. `medium`: The baseline size, scaled to 100% (unchanged from the base size).
8. `slightlyLarge`: A slightly larger size, scaled to 110% of the base size.
9. `large`: A noticeably larger size, scaled to 125% of the base size.
10. `veryLarge`: A significantly larger size, scaled to 150% of the base size.
11. `extraLarge`: A very large size, scaled to 175% of the base size.
12. `extraExtraLarge`: An extremely large size, scaled to 200% of the base size.
13. `huge`: A massive size, scaled to 250% of the base size.
14. `massive`: The largest predefined size, scaled to 300% of the base size.

**Custom Size Option**

The function also allows for a `custom` size category. This option enables users to specify a custom scale factor using the `options.scale` property. If the `custom` size is selected and a specific `scale` value is provided in the `options` object, the gene marker will be scaled according to that value. If no custom `scale` is provided, the marker defaults to a scale of `1` (the base size).